### PR TITLE
warn on missing stat

### DIFF
--- a/src/weapon.ts
+++ b/src/weapon.ts
@@ -38,7 +38,8 @@ export function extractNumber(weapon: Weapon, path: string): number {
     if (part in current) {
       current = current[part];
     } else {
-      throw Error(`Invalid stat path specified: ${path}`);
+      console.warn(`Invalid stat ${weapon.name} path specified: ${path}`);
+      return 0;
     }
   }
   return current as unknown as number;


### PR DESCRIPTION
Its probably better to just warn and return 0 than break the whole app when there's bad data entry. Makes it easier to debug too.